### PR TITLE
Add --wgs option for non-amplicon data

### DIFF
--- a/tests/tasks_test.py
+++ b/tests/tasks_test.py
@@ -32,6 +32,7 @@ def test_assemble():
     options.min_amp_overlap_len = 20
     options.contig_map_end_allowance = 20
     options.amplicons_to_fail_file = None
+    options.wgs = False
     options.debug = True
     got = tasks.assemble.run(options)
     expect_fa = os.path.join(data_dir, "run_assembly_pipeline.expect.fa")

--- a/viridian/__main__.py
+++ b/viridian/__main__.py
@@ -38,7 +38,9 @@ def main(args=None):
     )
     subparser_assemble.add_argument("outdir", help="Output directory")
 
-    reads_group = subparser_assemble.add_argument_group("Reads options. Must use: --bam; or --reads_to_map; or --reads_to_map and --mates_to_map")
+    reads_group = subparser_assemble.add_argument_group(
+        "Reads options. Must use: --bam; or --reads_to_map; or --reads_to_map and --mates_to_map"
+    )
     reads_group.add_argument(
         "--bam",
         help="Input reads in a sorted indexed BAM file",
@@ -90,7 +92,7 @@ def main(args=None):
     )
     subparser_assemble.add_argument(
         "--min_read_length",
-        help="Only use reads at least this long (after trimming with --read_end_trim) [%(default)s]",
+        help="Only use reads at least this long (after trimming with --read_end_trim). If the --wgs is used, then the reads must also overlap an 'amplicons' by at least this length to be used [%(default)s]",
         default=200,
         type=int,
         metavar="INT",
@@ -127,6 +129,11 @@ def main(args=None):
         "--amplicons_to_fail_file",
         help="File of amplicon names to force to count as failed. One name in each line of the file. Names must exactly match those in amplicons_bed file",
         metavar="FILENAME",
+    )
+    subparser_assemble.add_argument(
+        "--wgs",
+        help="Use this flag if the reads are not from amplicons (eg are WGS or SISPA). It drops the assumption that reads are sequenced from amplicons. This flag is essential if you do not have amplicon data.",
+        action="store_true",
     )
     subparser_assemble.add_argument(
         "--force",

--- a/viridian/tasks/assemble.py
+++ b/viridian/tasks/assemble.py
@@ -3,18 +3,25 @@ from viridian import assemble, utils
 
 def run(options):
     if not utils.look_for_required_binaries_in_path():
-        raise Exception("At least one required program was not found in $PATH. Cannot continue")
+        raise Exception(
+            "At least one required program was not found in $PATH. Cannot continue"
+        )
 
     if options.bam is None:
         if options.reads_to_map is None:
-            raise Exception("Must provide either --bam or --reads_to_map. Cannot continue")
+            raise Exception(
+                "Must provide either --bam or --reads_to_map. Cannot continue"
+            )
     else:
         if options.reads_to_map is not None:
-            raise Exception("Cannot use both options --bam and --reads_to_map. Please use one of these options")
+            raise Exception(
+                "Cannot use both options --bam and --reads_to_map. Please use one of these options"
+            )
 
     if options.mates_to_map is not None and options.reads_to_map is None:
-        raise Exception("--mates_to_map was used, but --reads_to_map was not. --reads_to_map is required by --mates_to_map")
-
+        raise Exception(
+            "--mates_to_map was used, but --reads_to_map was not. --reads_to_map is required by --mates_to_map"
+        )
 
     if options.force:
         utils.rm_rf(options.outdir)
@@ -43,5 +50,6 @@ def run(options):
         min_amp_overlap_len=options.min_amp_overlap_len,
         contig_map_end_allowance=options.contig_map_end_allowance,
         amplicons_to_fail=amplicons_to_fail,
+        wgs=options.wgs,
         debug=options.debug,
     )


### PR DESCRIPTION
Adds a command line option `--wgs` to use with non-amplicon data. The assembly still works by processing each "amplicon" in turn, but this flag drops the assumption that reads are sequenced from amplicons. Without it, not enough reads are chosen to polish each amplicon.