### PR TITLE
Set default opts, add required argument 'tech'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,19 @@ Required input:
 
 Run using a mapped BAM file of ONT reads:
 ```
-viridian assemble --bam reads.bam ref.fasta amplicons.bed outdir
+viridian assemble --bam reads.bam ont ref.fasta amplicons.bed outdir
 ```
 
 Run using a FASTQ file of ONT reads:
 ```
-viridian assemble --reads_to_map reads.fastq ref.fasta amplicons.bed outdir
+viridian assemble --reads_to_map reads.fastq ont ref.fasta amplicons.bed outdir
 ```
 
 Run using two FASTQ files of paired Illumina reads:
 ```
 viridian assemble \
   --reads_to_map reads1.fastq --mates_to_map reads2.fastq \
-  --minimap_opts "-t 1 -x sr" \
-  --min_read_length 50 \
-  ref.fasta amplicons.bed outdir
+  illumina ref.fasta amplicons.bed outdir
 ```
 
 

--- a/viridian/__main__.py
+++ b/viridian/__main__.py
@@ -86,7 +86,7 @@ def main(args=None):
     subparser_assemble.add_argument(
         "--read_map_tolerance",
         help="Max allowed distance read start or end can be outside amplicon coords [%(default)s]",
-        default=20,
+        default=5,
         type=int,
         metavar="INT",
     )

--- a/viridian/__main__.py
+++ b/viridian/__main__.py
@@ -5,6 +5,23 @@ import logging
 import viridian
 
 
+TECH_DEPENDENT_DEFAULTS = {
+    "minimap_opts": {"illumina": "-t 1 -x sr", "ont": "-t 1 -x map-ont"},
+    "target_coverage": {"illumina": 150, "ont": 250},
+    "min_read_length": {"illumina": 50, "ont": 200},
+}
+
+
+def tech_dependent_usage_default_string(option):
+    return "; ".join([f"{k}:{v}" for k, v in TECH_DEPENDENT_DEFAULTS[option].items()])
+
+
+def set_tech_dependent_args(args):
+    for option in TECH_DEPENDENT_DEFAULTS:
+        if getattr(args, option) is None:
+            setattr(args, option, TECH_DEPENDENT_DEFAULTS[option][args.tech])
+
+
 def main(args=None):
     parser = argparse.ArgumentParser(
         prog="viridian",
@@ -25,9 +42,15 @@ def main(args=None):
     subparser_assemble = subparsers.add_parser(
         "assemble",
         help="Reference-guided assembly from reads",
-        usage="viridian assemble [options] <ref_fasta> <amplicons_bed> <outdir>",
+        usage="viridian assemble [options] <tech> <ref_fasta> <amplicons_bed> <outdir>",
         description="Reference-guided assembly from reads",
         epilog="Required: --bam, or --reads_to_map, or both --reads_to_map and --mates_to_map",
+    )
+    subparser_assemble.add_argument(
+        "tech",
+        help="Sequencing technology. Must be 'ont' or 'illumina'",
+        choices=["ont", "illumina"],
+        metavar="tech",
     )
     subparser_assemble.add_argument(
         "ref_fasta",
@@ -58,9 +81,8 @@ def main(args=None):
     )
     subparser_assemble.add_argument(
         "--minimap_opts",
-        help="Options string to pass to minimap2. Is used for initial mapping if reads provided with --reads_to_map, otherwise is ignored. Do not use -a or -o! This string is not sanity checked - it is up to you to provide valid options. Default is to use 1 thread and the Nanopore preset [%(default)s]",
+        help=f"Options string to pass to minimap2. Is used for initial mapping if reads provided with --reads_to_map, otherwise is ignored. Do not use -a or -o! This string is not sanity checked - it is up to you to provide valid options. Default is to use 1 thread and the Nanopore preset [{tech_dependent_usage_default_string('minimap_opts')}]",
         metavar="STRING",
-        default="-t 1 -x map-ont",
     )
     subparser_assemble.add_argument(
         "--min_mean_coverage",
@@ -71,8 +93,7 @@ def main(args=None):
     )
     subparser_assemble.add_argument(
         "--target_coverage",
-        help="Aim for this much coverage when extracting reads for polishing [%(default)s]",
-        default=500,
+        help=f"Aim for this much coverage when extracting reads for polishing [{tech_dependent_usage_default_string('target_coverage')}]",
         type=int,
         metavar="INT",
     )
@@ -92,8 +113,7 @@ def main(args=None):
     )
     subparser_assemble.add_argument(
         "--min_read_length",
-        help="Only use reads at least this long (after trimming with --read_end_trim). If the --wgs is used, then the reads must also overlap an 'amplicons' by at least this length to be used [%(default)s]",
-        default=200,
+        help=f"Only use reads at least this long (after trimming with --read_end_trim). If the --wgs is used, then the reads must also overlap an 'amplicons' by at least this length to be used [{tech_dependent_usage_default_string('min_read_length')}]",
         type=int,
         metavar="INT",
     )
@@ -178,6 +198,7 @@ def main(args=None):
     subparser_amp_over.set_defaults(func=viridian.tasks.amplicon_overlap.run)
 
     args = parser.parse_args()
+    set_tech_dependent_args(args)
 
     logging.basicConfig(
         format="[%(asctime)s viridian %(levelname)s] %(message)s",

--- a/viridian/assemble.py
+++ b/viridian/assemble.py
@@ -1,3 +1,4 @@
+import argparse
 import datetime
 import json
 import logging
@@ -105,15 +106,27 @@ def run_assembly_pipeline(
     amplicons_to_fail=None,
     wgs=False,
     debug=False,
+    command_line_args=None,
 ):
+    # Make a dict of the command line options to go in the JSON output file.
+    # The tests don't use argparse (they use Mock), which means convert to dict
+    # doesn't work. Don't care about that case anyway in the final output, so
+    # just set to None
+    if isinstance(command_line_args, argparse.Namespace):
+        options_dict = {k: v for k, v in vars(command_line_args).items() if k != "func"}
+    else:
+        options_dict = None
+
     start_time = datetime.datetime.now()
     os.mkdir(outdir)
     json_out = os.path.join(outdir, "run_info.json")
+
     json_data = {
         "run_summary": {
             "total_amplicons": None,
             "successful_amplicons": None,
             "command": " ".join(sys.argv),
+            "options": options_dict,
             "cwd": os.getcwd(),
             "version": viridian_version,
             "finished_running": False,

--- a/viridian/tasks/assemble.py
+++ b/viridian/tasks/assemble.py
@@ -52,4 +52,5 @@ def run(options):
         amplicons_to_fail=amplicons_to_fail,
         wgs=options.wgs,
         debug=options.debug,
+        command_line_args=options,
     )


### PR DESCRIPTION
Sets some default options (based on testing on our truth set). Also adds required command line argument "tech", which must be "illumina" or "ont", and some defaults depend on the value of this option (user can override).

Also adds a dict of the options to the file `run_info.json`.