### PR TITLE
Improve run summary json

### DIFF
--- a/tests/assemble_test.py
+++ b/tests/assemble_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pytest
 
@@ -57,4 +58,14 @@ def test_run_assembly_pipeline():
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
     assert got == consensus_from_file.seq
+
+    # some checks of the contents of the json summary
+    with open(os.path.join(outdir, "run_info.json")) as f:
+        run_info = json.load(f)
+    assert run_info["run_summary"]["made_consensus"] is True
+    assert run_info["run_summary"]["amplicon_success"] == {
+        "a1": False, "a2": True, "a3": True,
+    }
+    assert run_info["run_summary"]["successful_amplicons"] == 2
+    assert run_info["run_summary"]["total_amplicons"] == 3
     utils.rm_rf(outdir)

--- a/tests/assemble_test.py
+++ b/tests/assemble_test.py
@@ -68,4 +68,6 @@ def test_run_assembly_pipeline():
     }
     assert run_info["run_summary"]["successful_amplicons"] == 2
     assert run_info["run_summary"]["total_amplicons"] == 3
+    assert run_info["run_summary"]["consensus_length"] == 623
+    assert run_info["run_summary"]["consensus_N_count"] == 0
     utils.rm_rf(outdir)

--- a/viridian/assemble.py
+++ b/viridian/assemble.py
@@ -92,6 +92,7 @@ def add_successful_amplicons_to_json_data(data, amplicons):
     data["run_summary"]["successful_amplicons"] = len(
         [a for a in amplicons if a.assemble_success]
     )
+    data["run_summary"]["amplicon_success"] = {a.name: a.assemble_success for a in amplicons}
 
 
 def run_assembly_pipeline(

--- a/viridian/assemble.py
+++ b/viridian/assemble.py
@@ -95,6 +95,14 @@ def add_successful_amplicons_to_json_data(data, amplicons):
     data["run_summary"]["amplicon_success"] = {a.name: a.assemble_success for a in amplicons}
 
 
+def add_consensus_length_N_count_to_json_data(data):
+    if data["run_summary"]["made_consensus"]:
+        data["run_summary"]["consensus_length"] = len(data["run_summary"]["consensus"])
+        data["run_summary"]["consensus_N_count"] = data["run_summary"]["consensus"].count("N")
+    else:
+        data["run_summary"]["consensus_length"] = None
+        data["run_summary"]["consensus_N_count"] = None
+
 def run_assembly_pipeline(
     ref_fasta,
     amplicons_json,
@@ -229,6 +237,8 @@ def run_assembly_pipeline(
     else:
         logging.info("Finished making consensus sequence.")
         json_data["run_summary"]["made_consensus"] = True
+
+    add_consensus_length_N_count_to_json_data(json_data)
     json_data["amplicons"] = amps.amplicons_to_list_of_dicts(amplicons)
     json_data["run_summary"]["finished_running"] = True
     end_time = datetime.datetime.now()


### PR DESCRIPTION
Adds entries to `run_summary` section of `run_info.json`:
* `amplicon_success` - dict of amplicon name -> bool of successful or not
* `consensus_length` - length of consensus sequence (or `null` if no consensus)
* `consensus_N_count` - number of Ns in consensus (or `null` if no consensus)