### PR TITLE
Include first and last primer in consensus

### DIFF
--- a/tests/amplicon_overlapper_test.py
+++ b/tests/amplicon_overlapper_test.py
@@ -43,32 +43,32 @@ def test_amplicons_to_consensus_contigs():
     amplicons[0].masked_seq = "CCCCGTAACCGAGCTCACCAGCGAATCACAA"
     amplicons[0].assemble_success = True
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    assert got_contigs == [amplicons[0].masked_seq[1:-2]]
+    assert got_contigs == [amplicons[0].masked_seq[0:-2]]
 
     amplicons[1].masked_seq = "TCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGG"
     amplicons[1].assemble_success = True
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = ["CCCGTAACCGAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACT"]
+    expect = ["CCCCGTAACCGAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACT"]
     assert got_contigs == expect
 
     amplicons[2].masked_seq = "NNCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAANN"
     amplicons[2].assemble_success = True
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
     expect = [
-        "CCCGTAACCGAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGA"
+        "CCCCGTAACCGAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAA"
     ]
     assert got_contigs == expect
 
     amplicons[1].masked_seq = None
     amplicons[1].assemble_success = False
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = [amplicons[0].masked_seq[1:-2], amplicons[2].masked_seq[5:-6]]
+    expect = [amplicons[0].masked_seq[0:-2], amplicons[2].masked_seq[5:].rstrip("N")]
     assert got_contigs == expect
 
     amplicons[0].masked_seq = None
     amplicons[0].assemble_success = False
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = [amplicons[2].masked_seq[5:-6]]
+    expect = [amplicons[2].masked_seq[5:].rstrip("N")]
     assert got_contigs == expect
 
     amplicons[0].masked_seq = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
@@ -77,7 +77,7 @@ def test_amplicons_to_consensus_contigs():
     amplicons[0].assemble_success = False
     amplicons[1].assemble_success = False
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = [amplicons[2].masked_seq[5:-6].strip("N")]
+    expect = [amplicons[2].masked_seq[5:].strip("N")]
     assert got_contigs == expect
 
 
@@ -112,7 +112,7 @@ def test_amplicons_to_consensus_contigs_2():
     amplicons[5].masked_seq = ref[100:130]
     amplicons[5].assemble_success = True
     got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 7)
-    assert got_contigs == [ref[1:48], ref[82:127]]
+    assert got_contigs == [ref[0:48], ref[82:129]]
 
 
 def test_consensus_contigs_to_consensus():
@@ -185,7 +185,7 @@ def test_assemble_amplicons():
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == amplicons[0].masked_seq[1:-2]
+    assert got == amplicons[0].masked_seq[0:-2]
     utils.rm_rf(f"{outprefix}.*")
 
     amplicons[1].masked_seq = ref_seq[250:545]
@@ -193,7 +193,7 @@ def test_assemble_amplicons():
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == ref_seq[21:541]
+    assert got == ref_seq[20:541]
     utils.rm_rf(f"{outprefix}.*")
 
     amplicons[3].masked_seq = ref_seq[790:952]
@@ -201,7 +201,7 @@ def test_assemble_amplicons():
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == ref_seq[21:541] + "N" * 256 + ref_seq[797:944]
+    assert got == ref_seq[20:541] + "N" * 256 + ref_seq[797:951]
     utils.rm_rf(f"{outprefix}.*")
 
     # putting in junk for amplicon 2 means it won't overlap amplicons 1 or 3,
@@ -213,5 +213,5 @@ def test_assemble_amplicons():
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == ref_seq[21:299]
+    assert got == ref_seq[20:299]
     utils.rm_rf(f"{outprefix}.*")

--- a/tests/assemble_test.py
+++ b/tests/assemble_test.py
@@ -71,7 +71,7 @@ def test_run_assembly_pipeline():
     expect_seq = utils.load_single_seq_fasta(expect_fa)
     # expected fasta is the fasta used to generate the reads. But the amplicons
     # don't cover the whole genome, so we expect to miss the ends
-    assert got == expect_seq[11:979]
+    assert got == expect_seq[11:988]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -91,7 +91,7 @@ def test_run_assembly_pipeline():
         min_depth_for_not_N=1,
         read_end_trim=1,
     )
-    assert got == expect_seq[11:979]
+    assert got == expect_seq[10:988]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -115,7 +115,7 @@ def test_run_assembly_pipeline():
     expect_seq = utils.load_single_seq_fasta(expect_fa)
     # This time, we should not have the first amplicon, and the returned
     # sequence should start with the second amplicon
-    assert got == expect_seq[356:979]
+    assert got == expect_seq[356:988]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -132,6 +132,6 @@ def test_run_assembly_pipeline():
     }
     assert run_info["run_summary"]["successful_amplicons"] == 2
     assert run_info["run_summary"]["total_amplicons"] == 3
-    assert run_info["run_summary"]["consensus_length"] == 623
+    assert run_info["run_summary"]["consensus_length"] == 632
     assert run_info["run_summary"]["consensus_N_count"] == 0
     utils.rm_rf(outdir)

--- a/tests/tasks_test.py
+++ b/tests/tasks_test.py
@@ -40,7 +40,7 @@ def test_assemble():
     expect_seq = utils.load_single_seq_fasta(expect_fa)
     # expected fasta is the fasta used to generate the reads. But the amplicons
     # don't cover the whole genome, so we expect to miss the ends
-    assert got == expect_seq[11:979]
+    assert got == expect_seq[11:988]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -55,7 +55,7 @@ def test_assemble():
     got = tasks.assemble.run(options)
     expect_fa = os.path.join(data_dir, "run_assembly_pipeline.expect.fa")
     expect_seq = utils.load_single_seq_fasta(expect_fa)
-    assert got == expect_seq[356:979]
+    assert got == expect_seq[356:988]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )

--- a/viridian/amplicon_overlapper.py
+++ b/viridian/amplicon_overlapper.py
@@ -48,12 +48,16 @@ def amplicons_to_consensus_contigs(amplicons, min_match_length=20):
             f"Overlapping amplicons. Processing {amplicons[i].name}. Assemble succes: {amplicons[i].assemble_success}"
         )
         if amplicons[i].assemble_success:
-            if i == 0 or overlaps[i - 1] is None:
+            if i == 0:
+                start = 0
+            elif overlaps[i - 1] is None:
                 start = amplicons[i].left_primer_length
             else:
                 start = max(overlaps[i - 1].b, 0)
 
-            if i > len(overlaps) - 1 or overlaps[i] is None:
+            if i > len(overlaps) - 1:
+                end = len(amplicons[i].masked_seq) - 1
+            elif overlaps[i] is None:
                 end = len(amplicons[i].masked_seq) - amplicons[i].right_primer_length
             else:
                 end = overlaps[i].a


### PR DESCRIPTION
Changes amplicon overlapper, so that it includes the left primer of the first amplicon, and right primer of last amplicon instead of leaving out that sequence.