### PR TITLE
Fail amps with too many Ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - When building consensus from contigs, if a contig does not map then remove
   the contig and carry on, instead of aborting the entire assembly
 
+- Fail amplicon if its sequence after stripping Ns is less than 3/4 of
+  (length of the amplicon - primer lengths)
+
 ### Removed
 
 - Removed the command line function `viridian amplicon_overlap`.

--- a/cylon/amplicons.py
+++ b/cylon/amplicons.py
@@ -36,6 +36,9 @@ class Amplicon:
     def __eq__(self, other):
         return type(other) is type(self) and self.__dict__ == other.__dict__
 
+    def non_primer_length(self):
+        return len(self) - self.left_primer_length - self.right_primer_length
+
     def to_dict(self):
         return {
             "name": self.name,
@@ -271,6 +274,10 @@ class Amplicon:
             percent_N = 100 * proportion_masked
             self.polish_data["Comments"].append(
                 f"Too many Ns ({percent_N}%) after masking polished sequence (not including Ns at the start/end)"
+            )
+        elif len(masked_strip_ns) < 0.75 * self.non_primer_length():
+            self.polish_data["Comments"].append(
+                f"N-stripped sequence is shorter than 75% of (amplicon length - primers lengths)"
             )
         else:
             self.polish_data["Polish success"] = True


### PR DESCRIPTION
Fail amplicon if its sequence after stripping Ns is less than 3/4 of (length of the amplicon - primer lengths). Otherwise it's got no chance of overlapping adjacent amplicon, and then they both get failed.