### PR TITLE
Overlapper rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - When building consensus from contigs, if a contig does not map then remove
   the contig and carry on, instead of aborting the entire assembly
 
-- Fail amplicon if its sequence after stripping Ns is less than 3/4 of
-  (length of the amplicon - primer lengths)
+- Rewrite overlapper to use more amplicons, and also use more of each amplicon
+  (less trimming at ends). New method is more tolerant of failed amplicons,
+  still keeping adjacent amplicons.
+
+
 
 ### Removed
 

--- a/cylon/__main__.py
+++ b/cylon/__main__.py
@@ -140,13 +140,6 @@ def main(args=None):
         metavar="INT",
     )
     subparser_assemble.add_argument(
-        "--min_amp_overlap_len",
-        help="Minimum perfect overlap length required when overlapping each polished amplicon [%(default)s]",
-        default=20,
-        type=int,
-        metavar="INT",
-    )
-    subparser_assemble.add_argument(
         "--contig_map_end_allowance",
         help="When mapping contigs ends to the reference to fill in failed amplicons with Ns, allow the mapping to start up to this distance away from the contig end [%(default)s]",
         default=20,

--- a/cylon/amplicon_overlapper.py
+++ b/cylon/amplicon_overlapper.py
@@ -206,7 +206,7 @@ def _get_starts_and_ends(perfect_overlaps, amplicons, ref_matches):
                         fails.add(i)
                     else:
                         starts_ends[i][1] = end
-                        starts_end[i+1][0] = start
+                        starts_ends[i+1][0] = start
                 else:
                     starts_ends[i][1] = perfect_ol.a
                     starts_ends[i+1][0] = max(perfect_ol.b, 0)

--- a/cylon/amplicon_overlapper.py
+++ b/cylon/amplicon_overlapper.py
@@ -156,6 +156,7 @@ def _get_amplicon_ref_matches(amplicons, ref_fasta, outfile, debug=False):
             if i in matches and matches[i]["len"] > new_match["len"]:
                 continue
             matches[i] = new_match
+            amplicons[i].ref_match = new_match
 
     return matches
 

--- a/cylon/amplicons.py
+++ b/cylon/amplicons.py
@@ -298,9 +298,12 @@ class Amplicon:
         if not debug:
             utils.rm_rf(outdir)
 
-    def final_overlap(self, other, min_match_length):
+    def final_overlap(self, other, min_match_length, self_start=0, other_end=None):
         if self.final_seq is None or other.final_seq is None:
             return None
+
+        if other_end is None:
+            other_end = len(other.final_seq)
 
         # SequenceMatcher has junk=foo option, which would have been nice
         # to use to get it to not align Ns, but I couldn't get it to work and
@@ -314,7 +317,7 @@ class Amplicon:
             autojunk=False,
         )
         match = seq_matcher.find_longest_match(
-            0, len(self.final_seq), 0, len(other.final_seq)
+            self_start, len(self.final_seq), 0, other_end
         )
         return match if match.size >= min_match_length else None
 

--- a/cylon/amplicons.py
+++ b/cylon/amplicons.py
@@ -21,6 +21,7 @@ class Amplicon:
         self.masked_seq = None
         self.final_seq = None
         self.assemble_success = False
+        self.ref_match = None
         self.polish_data = {
             "Reads matching": 0,
             "Reads matching forward strand": 0,
@@ -52,6 +53,7 @@ class Amplicon:
             "final_seq": self.final_seq,
             "assemble_success": self.assemble_success,
             "polish_data": self.polish_data,
+            "ref_match": self.ref_match,
         }
 
     def clear_seqs_because_overlap_fail(self):

--- a/cylon/amplicons.py
+++ b/cylon/amplicons.py
@@ -19,6 +19,7 @@ class Amplicon:
         self.right_primer_length = right_primer_length
         self.polished_seq = None
         self.masked_seq = None
+        self.final_seq = None
         self.assemble_success = False
         self.polish_data = {
             "Reads matching": 0,
@@ -48,6 +49,7 @@ class Amplicon:
             "right_primer_length": self.right_primer_length,
             "polished_seq": self.polished_seq,
             "polished_masked_seq": self.masked_seq,
+            "final_seq": self.final_seq,
             "assemble_success": self.assemble_success,
             "polish_data": self.polish_data,
         }
@@ -55,8 +57,16 @@ class Amplicon:
     def clear_seqs_because_overlap_fail(self):
         self.polished_seq = None
         self.masked_seq = None
+        self.final_seq = None
         self.assemble_success = False
         self.polish_data["Comments"].append("No overlap with adjacent amplicon")
+
+    def clear_seqs_because_no_ref_match(self):
+        self.polished_seq = None
+        self.masked_seq = None
+        self.final_seq = None
+        self.assemble_success = False
+        self.polish_data["Comments"].append("No match to reference")
 
     def force_polish_fail(self):
         self.polish_data["Comments"].append("User chose to fail, so no processing run")
@@ -263,21 +273,21 @@ class Amplicon:
             debug=debug,
         )
         logging.debug(f"masked: {self.masked_seq}")
-        masked_strip_ns = self.masked_seq.strip("N")
-        if len(masked_strip_ns) == 0:
+        self.final_seq = self.masked_seq.strip("N")
+        if len(self.final_seq) == 0:
             proportion_masked = 0
         else:
             proportion_masked = round(
-                masked_strip_ns.count("N") / len(masked_strip_ns), 2
+                self.final_seq.count("N") / len(self.final_seq), 2
             )
         if proportion_masked > max_polished_N_prop:
             percent_N = 100 * proportion_masked
             self.polish_data["Comments"].append(
                 f"Too many Ns ({percent_N}%) after masking polished sequence (not including Ns at the start/end)"
             )
-        elif len(masked_strip_ns) < 0.75 * self.non_primer_length():
+        elif len(self.final_seq) < 30:
             self.polish_data["Comments"].append(
-                f"N-stripped sequence is shorter than 75% of (amplicon length - primers lengths)"
+                f"Final polished masked sequence too short: {len(self.final_seq)}"
             )
         else:
             self.polish_data["Polish success"] = True
@@ -286,8 +296,8 @@ class Amplicon:
         if not debug:
             utils.rm_rf(outdir)
 
-    def masked_overlap(self, other, min_match_length):
-        if self.masked_seq is None or other.masked_seq is None:
+    def final_overlap(self, other, min_match_length):
+        if self.final_seq is None or other.final_seq is None:
             return None
 
         # SequenceMatcher has junk=foo option, which would have been nice
@@ -297,14 +307,15 @@ class Amplicon:
         # as junk and doesn't align anything.
         seq_matcher = SequenceMatcher(
             None,
-            a=self.masked_seq.replace("N", "x"),
-            b=other.masked_seq.replace("N", "y"),
+            a=self.final_seq.replace("N", "x"),
+            b=other.final_seq.replace("N", "y"),
             autojunk=False,
         )
         match = seq_matcher.find_longest_match(
-            0, len(self.masked_seq), 0, len(other.masked_seq)
+            0, len(self.final_seq), 0, len(other.final_seq)
         )
         return match if match.size >= min_match_length else None
+
 
     def expected_overlap_length(self, other):
         if self.end < other.start:

--- a/cylon/amplicons.py
+++ b/cylon/amplicons.py
@@ -220,7 +220,9 @@ class Amplicon:
         os.mkdir(outdir)
         if reads_file is None:
             if bam_to_slice_reads is None:
-                self.polish_data["Comments"].append(f"No reads provided. Calling this amplicon failed")
+                self.polish_data["Comments"].append(
+                    f"No reads provided. Calling this amplicon failed"
+                )
                 return
 
             reads_file = os.path.join(outdir, "reads.fa")
@@ -320,7 +322,6 @@ class Amplicon:
             self_start, len(self.final_seq), 0, other_end
         )
         return match if match.size >= min_match_length else None
-
 
     def expected_overlap_length(self, other):
         if self.end < other.start:

--- a/cylon/assemble.py
+++ b/cylon/assemble.py
@@ -125,7 +125,9 @@ def load_and_check_reads_amp_dir(reads_per_amp_dir, amplicons):
 
     for amplicon_name in manifest:
         if amplicon_name not in all_amp_names:
-            raise Exception(f"Amplicon '{amplicon_name}' in json {json_file} but not in amplicon scheme")
+            raise Exception(
+                f"Amplicon '{amplicon_name}' in json {json_file} but not in amplicon scheme"
+            )
 
         reads_file_full_path = os.path.join(reads_per_amp_dir, manifest[amplicon_name])
         if not os.path.exists(reads_file_full_path):

--- a/cylon/assemble.py
+++ b/cylon/assemble.py
@@ -153,7 +153,6 @@ def run_assembly_pipeline(
     min_read_length=200,
     racon_iterations=3,
     min_depth_for_not_N=5,
-    min_amp_overlap_len=20,
     contig_map_end_allowance=20,
     amplicons_to_fail=None,
     wgs=False,
@@ -267,7 +266,6 @@ def run_assembly_pipeline(
             amplicons,
             ref_fasta,
             overlap_out,
-            min_match_length=min_amp_overlap_len,
             ref_map_end_allowance=contig_map_end_allowance,
             debug=debug,
         )

--- a/cylon/assemble.py
+++ b/cylon/assemble.py
@@ -54,6 +54,8 @@ def polish_each_amplicon(
         amplicons_to_fail = set()
 
     for i, amplicon in enumerate(amplicons):
+        if i == len(amplicons) - 5:
+            logging.info("Processing the final five")
         logging.debug(
             f"Start processing amplicon {amplicon.name} ({i+1}/{len(amplicons)})"
         )

--- a/cylon/racon.py
+++ b/cylon/racon.py
@@ -6,7 +6,13 @@ import pyfastaq
 from cylon import utils
 
 
-def run_racon(seq_to_polish, reads_filename, outprefix, minimap_opts="-t 1 -x map-ont", debug=False):
+def run_racon(
+    seq_to_polish,
+    reads_filename,
+    outprefix,
+    minimap_opts="-t 1 -x map-ont",
+    debug=False,
+):
     if minimap_opts is None:
         minimap_opts = "-t 1 -x map-ont"
     fasta_to_polish = f"{outprefix}.to_polish.fa"
@@ -23,7 +29,8 @@ def run_racon(seq_to_polish, reads_filename, outprefix, minimap_opts="-t 1 -x ma
     # 500. So set it to be a bit more that the sequence we are correcting.
     window_length = len(seq_to_polish) + 100
     completed_process = utils.syscall(
-        f"racon --window-length {window_length} --no-trimming {reads_filename} {sam} {fasta_to_polish}", allow_fail=True
+        f"racon --window-length {window_length} --no-trimming {reads_filename} {sam} {fasta_to_polish}",
+        allow_fail=True,
     )
     if completed_process.returncode != 0:
         return None
@@ -41,7 +48,12 @@ def run_racon(seq_to_polish, reads_filename, outprefix, minimap_opts="-t 1 -x ma
 
 
 def run_racon_iterations(
-    seq_to_polish, reads_filename, outdir, max_iterations=3, debug=False, minimap_opts=None,
+    seq_to_polish,
+    reads_filename,
+    outdir,
+    max_iterations=3,
+    debug=False,
+    minimap_opts=None,
 ):
     reads_filename = os.path.abspath(reads_filename)
     os.mkdir(outdir)
@@ -49,7 +61,13 @@ def run_racon_iterations(
     for iteration in range(max_iterations):
         logging.debug(f"Start racon iteration {iteration}")
         outprefix = os.path.join(outdir, f"racon.{iteration}")
-        polished_seq = run_racon(seq_to_polish, reads_filename, outprefix, debug=debug, minimap_opts=minimap_opts)
+        polished_seq = run_racon(
+            seq_to_polish,
+            reads_filename,
+            outprefix,
+            debug=debug,
+            minimap_opts=minimap_opts,
+        )
         if polished_seq is None:
             return None
         if debug:

--- a/cylon/tasks/assemble.py
+++ b/cylon/tasks/assemble.py
@@ -51,7 +51,6 @@ def run(options):
         min_read_length=options.min_read_length,
         racon_iterations=options.racon_iterations,
         min_depth_for_not_N=options.min_depth_for_not_N,
-        min_amp_overlap_len=options.min_amp_overlap_len,
         contig_map_end_allowance=options.contig_map_end_allowance,
         amplicons_to_fail=amplicons_to_fail,
         wgs=options.wgs,

--- a/cylon/utils.py
+++ b/cylon/utils.py
@@ -29,7 +29,9 @@ def syscall(command, allow_fail=False, cwd=None):
         )
         raise Exception("Error in system call. Cannot continue")
 
-    logging.debug(f"Command finished with return code {completed_process.returncode}: {command}")
+    logging.debug(
+        f"Command finished with return code {completed_process.returncode}: {command}"
+    )
     return completed_process
 
 

--- a/tests/amplicon_overlapper_test.py
+++ b/tests/amplicon_overlapper_test.py
@@ -96,8 +96,8 @@ def test_amplicons_to_consensus_contigs_2():
         amps.Amplicon("amp5", 78, 119, 2, 1),
         amps.Amplicon("amp6", 100, 135, 1, 3),
     ]
-    #got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, ref_fa, minimap_out)
-    #assert got_contigs == None
+    # got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, ref_fa, minimap_out)
+    # assert got_contigs == None
     amplicons[0].final_seq = ref[0:34]
     amplicons[0].assemble_success = True
     amplicons[1].final_seq = ref[20:57]
@@ -110,7 +110,9 @@ def test_amplicons_to_consensus_contigs_2():
     amplicons[4].assemble_success = True
     amplicons[5].final_seq = ref[100:135]
     amplicons[5].assemble_success = True
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, ref_fa, minimap_out)
+    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(
+        amplicons, ref_fa, minimap_out
+    )
     assert got_contigs == [ref[0:57], ref[78:135]]
     os.unlink(ref_fa)
 

--- a/tests/amplicon_overlapper_test.py
+++ b/tests/amplicon_overlapper_test.py
@@ -12,21 +12,6 @@ data_dir = os.path.join(this_dir, "data", "amplicon_overlapper")
 Match = collections.namedtuple("Match", ("a", "b", "size"))
 
 
-def test_get_amplicon_overlaps():
-    amplicons = [
-        amps.Amplicon("a1", 10, 100, 1, 1),
-        amps.Amplicon("a2", 10, 100, 1, 1),
-        amps.Amplicon("a3", 110, 142, 1, 1),
-    ]
-    amplicons[1].final_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
-    amplicons[2].final_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
-
-    expect_overlaps = [None, Match(18, 2, 8)]
-    got_overlaps = amplicon_overlapper.get_amplicon_overlaps(amplicons, min_match_length=8)
-    assert got_overlaps == expect_overlaps
-    assert amplicon_overlapper.get_amplicon_overlaps(amplicons, min_match_length=9) == [None, None]
-
-
 def test_amplicons_to_consensus_contigs():
     f = amplicon_overlapper.amplicons_to_consensus_contigs
     # ref is 100bp of random sequence

--- a/tests/amplicon_overlapper_test.py
+++ b/tests/amplicon_overlapper_test.py
@@ -18,67 +18,76 @@ def test_get_amplicon_overlaps():
         amps.Amplicon("a2", 10, 100, 1, 1),
         amps.Amplicon("a3", 110, 142, 1, 1),
     ]
-    amplicons[1].masked_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
-    amplicons[2].masked_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
+    amplicons[1].final_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
+    amplicons[2].final_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
 
     expect_overlaps = [None, Match(18, 2, 8)]
-    got_overlaps = amplicon_overlapper.get_amplicon_overlaps(amplicons, 8)
+    got_overlaps = amplicon_overlapper.get_amplicon_overlaps(amplicons, min_match_length=8)
     assert got_overlaps == expect_overlaps
-    assert amplicon_overlapper.get_amplicon_overlaps(amplicons, 9) == [None, None]
+    assert amplicon_overlapper.get_amplicon_overlaps(amplicons, min_match_length=9) == [None, None]
 
 
 def test_amplicons_to_consensus_contigs():
+    f = amplicon_overlapper.amplicons_to_consensus_contigs
     # ref is 100bp of random sequence
     #                10        20        30        40        50        60        70        80        90
     #      0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-    # ref = "GGCAACAAGCCCCGTAACCCAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAACA"
+    ref = "GGCAACAAGCCCCGTAACCCAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAACA"
+    ref_fa = "tmp.amplicons_to_consensus_contigs.ref.fa"
+    minimap_out = "tmp.amplicons_to_consensus_contigs.paf"
+    utils.rm_rf(minimap_out)
+
+    with open(ref_fa, "w") as f_out:
+        print(">ref", ref, sep="\n", file=f_out)
+
     amplicons = [
         amps.Amplicon("amp1", 9, 39, 1, 2),
         amps.Amplicon("amp2", 24, 75, 3, 4),
         amps.Amplicon("amp3", 63, 99, 5, 6),
     ]
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 20)
+    got_contigs = f(amplicons, ref_fa, minimap_out)
     assert got_contigs == None
 
-    amplicons[0].masked_seq = "CCCCGTAACCGAGCTCACCAGCGAATCACAA"
+    amplicons[0].final_seq = "CCCCGTAACCCAGCTCACCAGCGAATCACAAGT"
     amplicons[0].assemble_success = True
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    assert got_contigs == [amplicons[0].masked_seq[0:-2]]
+    got_contigs = f(amplicons, ref_fa, minimap_out)
+    assert got_contigs == [amplicons[0].final_seq]
 
-    amplicons[1].masked_seq = "TCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGG"
+    amplicons[1].final_seq = "TCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGG"
     amplicons[1].assemble_success = True
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = ["CCCCGTAACCGAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACT"]
+    got_contigs = f(amplicons, ref_fa, minimap_out)
+    expect = ["CCCCGTAACCCAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGG"]
     assert got_contigs == expect
 
-    amplicons[2].masked_seq = "NNCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAANN"
+    amplicons[2].final_seq = "CAGAACACTTTGGCTCCTATGCACAGCGCGGACCAA"
     amplicons[2].assemble_success = True
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
+    got_contigs = f(amplicons, ref_fa, minimap_out)
     expect = [
-        "CCCCGTAACCGAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAA"
+        "CCCCGTAACCCAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAA"
     ]
     assert got_contigs == expect
 
-    amplicons[1].masked_seq = None
+    amplicons[1].final_seq = None
     amplicons[1].assemble_success = False
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = [amplicons[0].masked_seq[0:-2], amplicons[2].masked_seq[5:].rstrip("N")]
+    got_contigs = f(amplicons, ref_fa, minimap_out)
+    expect = [amplicons[0].final_seq, amplicons[2].final_seq]
     assert got_contigs == expect
 
-    amplicons[0].masked_seq = None
+    amplicons[0].final_seq = None
     amplicons[0].assemble_success = False
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = [amplicons[2].masked_seq[5:].rstrip("N")]
+    got_contigs = f(amplicons, ref_fa, minimap_out)
+    expect = [amplicons[2].final_seq]
     assert got_contigs == expect
 
-    amplicons[0].masked_seq = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-    amplicons[1].masked_seq = "TCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGG"
-    amplicons[2].masked_seq = "NNNNNNACACTTTGGCTCCTATGCACAGCGCGGANNNNNN"
+    amplicons[0].final_seq = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    amplicons[1].final_seq = "TCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGG"
+    amplicons[2].final_seq = "CAGAACACTTTGGCTCCTATGCACAGCGCGGACCA"
     amplicons[0].assemble_success = False
     amplicons[1].assemble_success = False
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 10)
-    expect = [amplicons[2].masked_seq[5:].strip("N")]
+    got_contigs = f(amplicons, ref_fa, minimap_out)
+    expect = [amplicons[2].final_seq]
     assert got_contigs == expect
+    os.unlink(ref_fa)
 
 
 def test_amplicons_to_consensus_contigs_2():
@@ -88,31 +97,37 @@ def test_amplicons_to_consensus_contigs_2():
     # ref is 130bp of random sequence
     #                10        20        30        40        50        60        70        80        90        100       110       120
     #      0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-    ref = "GGCAACAAGCCCCGTAACCCAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAACAGTCGATCGTTATCCTAACTCTACATACTAA"
+    ref = "GGCAACAAGCCCCGTAACCCAGCTCACCAGCGAATCACAAGTGTTAAGAGACAAAGAAGCGGCAGAACACTTTGGCTCCTATGCACAGCGCGGACCAACAGTCGATCGTTATCCTAACTCTACATACTAAGTGAC"
+    ref_fa = "tmp.amplicons_to_consensus_contigs_2.ref.fa"
+    minimap_out = "tmp.amplicons_to_consensus_contigs_2.paf"
+    utils.rm_rf(minimap_out)
+    with open(ref_fa, "w") as f_out:
+        print(">ref", ref, sep="\n", file=f_out)
     amplicons = [
-        amps.Amplicon("amp1", 0, 30, 1, 1),
-        amps.Amplicon("amp2", 20, 50, 1, 2),
+        amps.Amplicon("amp1", 0, 34, 1, 1),
+        amps.Amplicon("amp2", 20, 57, 1, 2),
         amps.Amplicon("amp3", 40, 70, 1, 1),
         amps.Amplicon("amp4", 60, 90, 1, 1),
-        amps.Amplicon("amp5", 80, 110, 2, 1),
-        amps.Amplicon("amp6", 100, 130, 1, 3),
+        amps.Amplicon("amp5", 78, 119, 2, 1),
+        amps.Amplicon("amp6", 100, 135, 1, 3),
     ]
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 7)
-    assert got_contigs == None
-    amplicons[0].masked_seq = ref[0:30]
+    #got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, ref_fa, minimap_out)
+    #assert got_contigs == None
+    amplicons[0].final_seq = ref[0:34]
     amplicons[0].assemble_success = True
-    amplicons[1].masked_seq = ref[20:50]
+    amplicons[1].final_seq = ref[20:57]
     amplicons[1].assemble_success = True
-    amplicons[2].masked_seq = ref[40:55] + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    amplicons[2].final_seq = ref[40:55] + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     amplicons[2].assemble_success = True
-    amplicons[3].masked_seq = "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG" + ref[75:90]
+    amplicons[3].final_seq = "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG" + ref[75:90]
     amplicons[3].assemble_success = True
-    amplicons[4].masked_seq = ref[80:110]
+    amplicons[4].final_seq = ref[78:119]
     amplicons[4].assemble_success = True
-    amplicons[5].masked_seq = ref[100:130]
+    amplicons[5].final_seq = ref[100:135]
     amplicons[5].assemble_success = True
-    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, 7)
-    assert got_contigs == [ref[0:48], ref[82:129]]
+    got_contigs = amplicon_overlapper.amplicons_to_consensus_contigs(amplicons, ref_fa, minimap_out)
+    assert got_contigs == [ref[0:57], ref[78:135]]
+    os.unlink(ref_fa)
 
 
 def test_consensus_contigs_to_consensus():
@@ -180,38 +195,26 @@ def test_assemble_amplicons():
     assert got is None
     utils.rm_rf(f"{outprefix}.*")
 
-    amplicons[0].masked_seq = ref_seq[20:301]
+    amplicons[0].final_seq = ref_seq[20:301]
     amplicons[0].assemble_success = True
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == amplicons[0].masked_seq[0:-2]
+    assert got == amplicons[0].final_seq
     utils.rm_rf(f"{outprefix}.*")
 
-    amplicons[1].masked_seq = ref_seq[250:545]
+    amplicons[1].final_seq = ref_seq[250:545]
     amplicons[1].assemble_success = True
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == ref_seq[20:541]
+    assert got == ref_seq[20:545]
     utils.rm_rf(f"{outprefix}.*")
 
-    amplicons[3].masked_seq = ref_seq[790:952]
+    amplicons[3].final_seq = ref_seq[790:952]
     amplicons[3].assemble_success = True
     got = amplicon_overlapper.assemble_amplicons(
         amplicons, ref_fasta, outprefix, debug=True
     )
-    assert got == ref_seq[20:541] + "N" * 256 + ref_seq[797:951]
-    utils.rm_rf(f"{outprefix}.*")
-
-    # putting in junk for amplicon 2 means it won't overlap amplicons 1 or 3,
-    # and we should only get amplicon 0 back
-    amplicons[
-        2
-    ].masked_seq = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCGGGGGGGGGGGGGGGGGGGGGGGGGGTTTTTTTTTTTTTTTTTTTTTT"
-    amplicons[2].assemble_success = True
-    got = amplicon_overlapper.assemble_amplicons(
-        amplicons, ref_fasta, outprefix, debug=True
-    )
-    assert got == ref_seq[20:299]
+    assert got == ref_seq[20:545] + "N" * 245 + ref_seq[790:952]
     utils.rm_rf(f"{outprefix}.*")

--- a/tests/amplicons_test.py
+++ b/tests/amplicons_test.py
@@ -227,6 +227,13 @@ def test_final_overlap():
     assert amp1.final_overlap(amp2, 0) == Match(2, 0, 1)
     assert amp1.final_overlap(amp2, 2) == None
 
+    amp1.final_seq = "NNNGGTGTGGCCTTTTTTTACTGATGCATGATTTTT"
+    amp2.final_seq = "TTTTTTGTGACGAAATTTTTTTTTTT"
+    assert amp1.final_overlap(amp2, 0) == Match(12, 15, 7)
+    assert amp1.final_overlap(amp2, 0, self_start=20) == Match(30, 14, 6)
+    assert amp1.final_overlap(amp2, 0, self_start=20, other_end=10) == Match(31, 0, 5)
+    assert amp1.final_overlap(amp2, 0, other_end=10) == Match(12, 0, 6)
+
 
 def test_load_amplicons_json_file():
     expect = [

--- a/tests/amplicons_test.py
+++ b/tests/amplicons_test.py
@@ -202,30 +202,30 @@ def test_polish():
     utils.rm_rf(outdir)
 
 
-def test_masked_overlap():
+def test_final_overlap():
     Match = collections.namedtuple("Match", ("a", "b", "size"))
     amp1 = amplicons.Amplicon("a1", 50, 100, 1, 1)
     amp2 = amplicons.Amplicon("a2", 90, 150, 1, 1)
-    assert amp1.masked_overlap(amp2, 10) is None
-    amp2.masked_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
-    assert amp1.masked_overlap(amp2, 10) is None
-    amp1.masked_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
-    amp2.masked_seq = None
-    assert amp1.masked_overlap(amp2, 10) is None
-    amp2.masked_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
-    assert amp1.masked_overlap(amp2, 7) == Match(18, 2, 8)
-    assert amp1.masked_overlap(amp2, 8) == Match(18, 2, 8)
-    assert amp1.masked_overlap(amp2, 9) == None
+    assert amp1.final_overlap(amp2, 10) is None
+    amp2.final_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
+    assert amp1.final_overlap(amp2, 10) is None
+    amp1.final_seq = "AAAAAAAAAAAAAAAAAATGCTGAACAGTCCCCCCC"
+    amp2.final_seq = None
+    assert amp1.final_overlap(amp2, 10) is None
+    amp2.final_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
+    assert amp1.final_overlap(amp2, 7) == Match(18, 2, 8)
+    assert amp1.final_overlap(amp2, 8) == Match(18, 2, 8)
+    assert amp1.final_overlap(amp2, 9) == None
 
-    amp1.masked_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
-    amp2.masked_seq = "NNAGGTGTGGCCTTTTTTTTTTTTTTTTTTTTTTTTTT"
-    assert amp1.masked_overlap(amp2, 10) == Match(34, 2, 10)
-    assert amp1.masked_overlap(amp2, 11) == None
+    amp1.final_seq = "CCTGCTGAACGGTTGATGCATCTCATGCTGACNNAGGTGTGGCCAAAAA"
+    amp2.final_seq = "NNAGGTGTGGCCTTTTTTTTTTTTTTTTTTTTTTTTTT"
+    assert amp1.final_overlap(amp2, 10) == Match(34, 2, 10)
+    assert amp1.final_overlap(amp2, 11) == None
 
-    amp1.masked_seq = "NNAGGTGTGGCCTTTTTTTTTTTTTTTTTTTTTTTTTT"
-    amp2.masked_seq = "AAAAAAAAAAAAAAAAANNNNNNNNNNN"
-    assert amp1.masked_overlap(amp2, 0) == Match(2, 0, 1)
-    assert amp1.masked_overlap(amp2, 2) == None
+    amp1.final_seq = "NNAGGTGTGGCCTTTTTTTTTTTTTTTTTTTTTTTTTT"
+    amp2.final_seq = "AAAAAAAAAAAAAAAAANNNNNNNNNNN"
+    assert amp1.final_overlap(amp2, 0) == Match(2, 0, 1)
+    assert amp1.final_overlap(amp2, 2) == None
 
 
 def test_load_amplicons_json_file():

--- a/tests/assemble_test.py
+++ b/tests/assemble_test.py
@@ -69,7 +69,7 @@ def test_run_assembly_pipeline():
     expect_seq = utils.load_single_seq_fasta(expect_fa)
     # expected fasta is the fasta used to generate the reads. But the amplicons
     # don't cover the whole genome, so we expect to miss the ends
-    assert got == expect_seq[11:988]
+    assert got == expect_seq[11:989]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -89,7 +89,7 @@ def test_run_assembly_pipeline():
         min_depth_for_not_N=1,
         read_end_trim=1,
     )
-    assert got == expect_seq[10:988]
+    assert got == expect_seq[10:989]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -113,7 +113,7 @@ def test_run_assembly_pipeline():
     expect_seq = utils.load_single_seq_fasta(expect_fa)
     # This time, we should not have the first amplicon, and the returned
     # sequence should start with the second amplicon
-    assert got == expect_seq[356:988]
+    assert got == expect_seq[351:989]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -130,6 +130,6 @@ def test_run_assembly_pipeline():
     }
     assert run_info["run_summary"]["successful_amplicons"] == 2
     assert run_info["run_summary"]["total_amplicons"] == 3
-    assert run_info["run_summary"]["consensus_length"] == 632
+    assert run_info["run_summary"]["consensus_length"] == 638
     assert run_info["run_summary"]["consensus_N_count"] == 0
     utils.rm_rf(outdir)

--- a/tests/tasks_test.py
+++ b/tests/tasks_test.py
@@ -30,7 +30,6 @@ def test_assemble():
     options.min_read_length = 200
     options.racon_iterations = 3
     options.min_depth_for_not_N = 1
-    options.min_amp_overlap_len = 20
     options.contig_map_end_allowance = 20
     options.amplicons_to_fail_file = None
     options.wgs = False
@@ -40,7 +39,7 @@ def test_assemble():
     expect_seq = utils.load_single_seq_fasta(expect_fa)
     # expected fasta is the fasta used to generate the reads. But the amplicons
     # don't cover the whole genome, so we expect to miss the ends
-    assert got == expect_seq[11:988]
+    assert got == expect_seq[11:989]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )
@@ -55,7 +54,7 @@ def test_assemble():
     got = tasks.assemble.run(options)
     expect_fa = os.path.join(data_dir, "run_assembly_pipeline.expect.fa")
     expect_seq = utils.load_single_seq_fasta(expect_fa)
-    assert got == expect_seq[356:988]
+    assert got == expect_seq[351:989]
     consensus_from_file = utils.load_single_seq_fasta(
         os.path.join(outdir, "consensus.final_assembly.fa")
     )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -13,6 +13,7 @@ def test_look_for_required_binaries_in_path():
     got = utils.look_for_required_binaries_in_path()
     assert got == True
 
+
 def test_load_single_seq_fasta():
     expect = pyfastaq.sequences.Fasta("seq", "ACGT")
     infile = os.path.join(data_dir, "load_single_seq_fasta.ok.fa")


### PR DESCRIPTION
Rewrite overlapper to keep more amplicons (instead of dropping too many amplicons adjacent to failed amplicon)