### PR TITLE
Update actions versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.16
       id: go
@@ -55,7 +55,7 @@ jobs:
 
 
     - name: Check out code for the container build
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set release version if is a release
       if: startsWith(github.event.ref, 'refs/tags/v')


### PR DESCRIPTION
Build currently fails. Need to update github actions versions used because of this:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

"Node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases), as a result we have started the deprecation process of Node 12 for GitHub Actions. 
...
For Actions users: Update your workflows with latest versions of the actions which runs on Node 16"